### PR TITLE
Calendar Animator Fix

### DIFF
--- a/src/animator/Animator.js
+++ b/src/animator/Animator.js
@@ -3,11 +3,14 @@ import gsap from "gsap";
 class Animator {
     animate(){
         let tl = gsap.timeline();
-        tl.set(".animator", { opacity: 0, y: 50 });
+        tl.set(".animator", { 
+            opacity: 0, 
+            css: {marginTop: 50}
+        });
         tl.to(".animator", {
             duration: 0.4,
             opacity: 1,
-            y: 0,
+            css: {marginTop: 0},
             stagger: 0.07
         });
     }


### PR DESCRIPTION
Animator no longer uses the `y` alias to `transform: translateY()` to animate the position of `.animator` elements, instead uses its CSSPlugin to animate `margin-top`. Temp workaround, can cause issues on elements specifying a margin-top != 0